### PR TITLE
elm inspired HTTP API

### DIFF
--- a/src/main/scala/scalm/http/Http.scala
+++ b/src/main/scala/scalm/http/Http.scala
@@ -1,0 +1,137 @@
+package scalm
+package http
+
+import org.scalajs.dom.raw.XMLHttpRequest
+import cats.implicits._
+import scala.util.Try
+
+object Http {
+
+  /**
+    * Tries to transforms a response body of type String to a value of type A.
+    * @tparam A type of the successfully decoded response
+    */
+  type Decoder[A] = String => Either[String, A]
+
+  /**
+    * Send an HTTP request.
+    * @param resultToMessage transforms a successful or failed response into a Msg
+    * @param request the request
+    * @tparam A type of the successfully decoded response
+    * @tparam Msg a scalm Msg
+    * @return A Cmd that describes the HTTP request
+    */
+  def send[A, Msg](resultToMessage: Either[http.Error, A] => Msg,
+                   request: Request[A]): Cmd[Msg] =
+    Task
+      .RunObservable[http.Error, XMLHttpRequest] { observer =>
+        val xhr = new XMLHttpRequest
+        try {
+          request.headers.foreach(h => xhr.setRequestHeader(h.name, h.value))
+          xhr.timeout = request.timeout.map(_.toMillis.toDouble).getOrElse(0)
+          xhr.withCredentials = request.withCredentials
+          xhr.open(request.method.toString.toUpperCase, request.url)
+          xhr.onload = _ => observer.onNext(xhr)
+          xhr.onerror = _ => observer.onError(NetworkError)
+          xhr.ontimeout = _ => observer.onError(Timeout)
+          request.body match {
+            case EmptyBody =>
+              xhr.send(null)
+            case StringBody(contentType, body) =>
+              xhr.setRequestHeader("Content-Type", contentType)
+              xhr.send(body)
+          }
+        } catch {
+          case ex: Throwable => observer.onError(BadUrl(ex.getMessage))
+        }
+        () =>
+          xhr.abort()
+      }
+      .attempt(_.flatMap { xhr =>
+        val response = Response(
+          url = request.url,
+          status = Status(xhr.status, xhr.statusText),
+          headers = parseHeaders(xhr.getAllResponseHeaders()),
+          body = xhr.responseText
+        )
+        if (xhr.status < 200 || 300 <= xhr.status) {
+          Left(BadStatus(response))
+        } else {
+          request
+            .expect(response)
+            .leftMap(BadPayload(_, response))
+        }
+      })
+      .map(resultToMessage)
+
+  /**
+    * Create a GET request and interpret the response body as String.
+    * @param url the url
+    * @return a GET request
+    */
+  def getString(url: String): Request[String] =
+    Request(
+      method = Get,
+      headers = Nil,
+      url = url,
+      body = EmptyBody,
+      expect = r => Right(r.body),
+      timeout = None,
+      withCredentials = false
+    )
+
+  /**
+    * Create a GET request and try to decode the response body from String to A.
+    * @param url the url
+    * @param decoder tries to transform the body into some value of type A
+    * @tparam A the type of the successfully decoded response
+    * @return a GET request
+    */
+  def get[A](url: String, decoder: Decoder[A]): Request[A] =
+    Request(
+      method = Get,
+      headers = Nil,
+      url = url,
+      body = EmptyBody,
+      expect = r => decoder(r.body),
+      timeout = None,
+      withCredentials = false
+    )
+
+  /**
+    * Create a POST request and try to decode the response body from String to A.
+    * @param url the url
+    * @param body the body of the POST request
+    * @param decoder tries to transform the body into some value of type A
+    * @tparam A the type of the successfully decoded response
+    * @return a POST request
+    */
+  def post[A](url: String, body: Body, decoder: Decoder[A]): Request[A] =
+    Request(
+      method = Post,
+      headers = Nil,
+      url = url,
+      body = body,
+      expect = r => decoder(r.body),
+      timeout = None,
+      withCredentials = false
+    )
+
+  /**
+    * Create a JSON body. This will automatically add the `Content-Type: application/json` header.
+    * @param body the JSON value as String
+    * @return a request body
+    */
+  def jsonBody(body: String): Body = StringBody("application/json", body)
+
+  private def parseHeaders(headers: String): Map[String, String] = {
+    headers
+      .split("[\\u000d\\u000a]+")
+      .flatMap(h =>
+        Try {
+          val Array(fst, scd) = h.split(":").map(_.trim()).slice(0, 2)
+          (fst, scd)
+        }.toOption)
+      .toMap
+  }
+}

--- a/src/main/scala/scalm/http/Models.scala
+++ b/src/main/scala/scalm/http/Models.scala
@@ -1,0 +1,108 @@
+package scalm.http
+
+import scala.concurrent.duration.FiniteDuration
+
+/** An Error will be returned if something goes wrong with an HTTP request. */
+sealed trait Error
+
+/**
+  * A BadUrl means that the provide URL is not valid.
+  * @param msg error message
+  */
+final case class BadUrl(msg: String) extends Error
+
+/** A Timeout means that it took too long to get a response. */
+case object Timeout extends Error
+
+/** A NetworkError means that there is a problem with the network. */
+case object NetworkError extends Error
+
+/**
+  * A BadStatus means that the status code of the response indicates failure.
+  * @param response the response
+  */
+final case class BadStatus(response: Response[String]) extends Error
+
+/**
+  * A BadPayload means that the body of the response could not be parsed correctly.
+  * @param decodingError debugging message that explains what went wrong
+  * @param response the response
+  */
+final case class BadPayload(decodingError: String, response: Response[String])
+    extends Error
+
+/** An HTTP method */
+sealed trait Method
+case object Get extends Method
+case object Post extends Method
+case object Put extends Method
+case object Patch extends Method
+case object Delete extends Method
+
+/** The body of a request */
+sealed trait Body
+
+/**
+  * Represents an empty body e.g. for GET requests or POST request without any data.
+  */
+case object EmptyBody extends Body
+
+/**
+  * Create a request body with a string.
+  * @param contentType the content type of the body
+  * @param body the content of the body
+  */
+final case class StringBody(contentType: String, body: String) extends Body
+
+/**
+  * A request header
+  * @param name header field name
+  * @param value header field value
+  */
+final case class Header(name: String, value: String)
+
+/**
+  * Describes an HTTP request.
+  * @param method GET, POST, PUT, PATCH or DELETE
+  * @param headers a list of request headers
+  * @param url the url
+  * @param body the request body (EmptyBody or StringBody(contentType: String, body: String))
+  * @param expect tries to transform a Response[String] to a value of type A
+  * @param timeout an optional timeout
+  * @param withCredentials indicates if the request is using credentials
+  * @tparam A type of the successfully decoded response
+  */
+final case class Request[A](
+    method: Method,
+    headers: List[Header],
+    url: String,
+    body: Body,
+    expect: Response[String] => Either[String, A],
+    timeout: Option[FiniteDuration],
+    withCredentials: Boolean
+)
+
+/**
+  * The response from an HTTP request.
+  * @param url the url
+  * @param status the status code
+  * @param headers the response headers
+  * @param body the response body
+  * @tparam A type of the response body
+  */
+final case class Response[A](
+    url: String,
+    status: Status,
+    headers: Map[String, String],
+    body: A
+)
+
+/**
+  * The response status code
+  * @param code the status code
+  * @param message the status message
+  */
+final case class Status(
+    code: Int,
+    message: String
+)


### PR DESCRIPTION
An implementation of HTTP models as well as helper functions for `GET` and `POST` requests.

The API design is very close to the design of the [elm-lang/http](http://package.elm-lang.org/packages/elm-lang/http/1.0.0/Http) package.
